### PR TITLE
Config for new rules: template-tag-spacing, no-multi-assign, and prefer-promise-reject-errors

### DIFF
--- a/rules/eslint/best-practices/off.js
+++ b/rules/eslint/best-practices/off.js
@@ -64,6 +64,7 @@ module.exports = {
         'no-void': 0,
         'no-warning-comments': 0,
         'no-with': 0,
+        'prefer-promise-reject-errors': 0,
         radix: 0,
         'require-await': 0,
         'vars-on-top': 0,

--- a/rules/eslint/best-practices/on.js
+++ b/rules/eslint/best-practices/on.js
@@ -64,6 +64,7 @@ module.exports = {
         'no-void': 0,
         'no-warning-comments': 0,
         'no-with': 2,
+        'prefer-promise-reject-errors': 2,
         radix: 2,
         'require-await': 0,
         'vars-on-top': 2,

--- a/rules/eslint/stylistic-issues/off.js
+++ b/rules/eslint/stylistic-issues/off.js
@@ -46,6 +46,7 @@ module.exports = {
         'no-lonely-if': 0,
         'no-mixed-operators': 0,
         'no-mixed-spaces-and-tabs': 0,
+        'no-multi-assign': 0,
         'no-multiple-empty-lines': 0,
         'no-negated-condition': 0,
         'no-nested-ternary': 0,
@@ -79,6 +80,7 @@ module.exports = {
         'space-infix-ops': 0,
         'space-unary-ops': 0,
         'spaced-comment': 0,
+        'template-tag-spacing': 0,
         'unicode-bom': 0,
         'wrap-regex': 0
     }

--- a/rules/eslint/stylistic-issues/on.js
+++ b/rules/eslint/stylistic-issues/on.js
@@ -46,6 +46,7 @@ module.exports = {
         'no-lonely-if': 0,
         'no-mixed-operators': 0,
         'no-mixed-spaces-and-tabs': 2,
+        'no-multi-assign': 2,
         'no-multiple-empty-lines': [2, { max: 1, maxEOF: 1 }],
         'no-negated-condition': 0,
         'no-nested-ternary': 0,
@@ -79,6 +80,7 @@ module.exports = {
         'space-infix-ops': 2,
         'space-unary-ops': [2, { words: false, nonwords: false }],
         'spaced-comment': 0,
+        'template-tag-spacing': [2, 'always'],
         'unicode-bom': 0,
         'wrap-regex': 0
     }


### PR DESCRIPTION
Related issues: 

- `template-tag-spacing` (Closes Casumo/eslint-config-casumo#7)
- `no-multi-assign` (Closes Casumo/eslint-config-casumo#8)
- `prefer-promise-reject-errors` (Closes Casumo/eslint-config-casumo#9)