### PR TITLE
Rule configs for no-compare-neg-zero and nonblock-statement-body-position

### DIFF
--- a/rules/eslint/possible-errors/off.js
+++ b/rules/eslint/possible-errors/off.js
@@ -1,6 +1,7 @@
 module.exports = {
     rules: {
         'no-await-in-loop': 0,
+        'no-compare-neg-zero': 0,
         'no-cond-assign': 0,
         'no-console': 0,
         'no-constant-condition': 0,

--- a/rules/eslint/possible-errors/on.js
+++ b/rules/eslint/possible-errors/on.js
@@ -1,6 +1,7 @@
 module.exports = {
     rules: {
         'no-await-in-loop': 0,
+        'no-compare-neg-zero': 2,
         'no-cond-assign': 0,
         'no-console': 0,
         'no-constant-condition': 0,

--- a/rules/eslint/stylistic-issues/off.js
+++ b/rules/eslint/stylistic-issues/off.js
@@ -59,6 +59,7 @@ module.exports = {
         'no-underscore-dangle': 0,
         'no-unneeded-ternary': 0,
         'no-whitespace-before-property': 0,
+        'nonblock-statement-body-position': 0,
         'object-curly-newline': 0,
         'object-curly-spacing': 0,
         'object-property-newline': 0,

--- a/rules/eslint/stylistic-issues/on.js
+++ b/rules/eslint/stylistic-issues/on.js
@@ -59,6 +59,7 @@ module.exports = {
         'no-underscore-dangle': 2,
         'no-unneeded-ternary': 0,
         'no-whitespace-before-property': 0,
+        'nonblock-statement-body-position': 2,
         'object-curly-newline': 0,
         'object-curly-spacing': 0,
         'object-property-newline': 0,


### PR DESCRIPTION
Added rule configs for the following new rules:
- [`no-compare-neg-zero`](http://eslint.org/docs/rules/no-compare-neg-zero#rule-details)
- [`nonblock-statement-body-position`](http://eslint.org/docs/rules/nonblock-statement-body-position#rule-details)

Both rules will throw an error if violated.