### PR TITLE
Jenkinsfile update: Slack msg and time triggers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,13 @@
 #!groovy
 try {
+    properties([
+        pipelineTriggers([
+            [
+                $class: 'hudson.triggers.TimerTrigger',
+                spec: "H 09 */1 * *"
+            ]
+        ])
+    ])
     node("ecs") {
         stage("Checkout") {
             checkout scm
@@ -11,7 +19,8 @@ try {
             sh("yarn test")
         }
     }
-} catch (err) {
-    def error = "${e}";
-    error "${error}"
+} catch (ex) {
+    def errorMessage = "[FAILURE]  💩  😭  😱  ${env.JOB_NAME} - Build #${env.BUILD_NUMBER} - ${env.BUILD_URL}console"
+    slackSend channel: "#frontend,", color: '#f05e5e', message: errorMessage
+    throw ex
 }


### PR DESCRIPTION
**What changed**:
- A periodic build will now run every day at 9am (this will help us be more proactive to new eslint rules available)
- A slack notification will be sent if the build fails.

**Notes**:
- Slack notification is being sent to `#frontend` for the time being - if it starts getting noisy we can move it to a different channel.
- There is no success slack notification since I do not think it is needed.